### PR TITLE
Removed the gunicorn variable that defined the total threads per worker

### DIFF
--- a/docker/gunicorn/gunicorn.conf.py
+++ b/docker/gunicorn/gunicorn.conf.py
@@ -1,7 +1,6 @@
 import multiprocessing
 
 workers = multiprocessing.cpu_count() * 2 + 1
-threads = workers
 proc_name = 'rapidpro'
 default_proc_name = proc_name
 accesslog = 'gunicorn.access'


### PR DESCRIPTION
A recurring problem in the infrastructure is that the project had a high memory consumption, after analyzing it I identified that the problem was being caused by the fact that when starting Gunicorn, it was defined that the total number of workers would be the total number of threads, following the logic, for each worker the same amount of threads was added, thus:

**worker * threads**

With this adjustment, memory usage drops significantly without affecting application performance