### PR TITLE
Update/rapidpro apps

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,8 @@ RUN rm /etc/nginx/sites-enabled/default
 
 COPY ./docker/pip-freeze.txt /tmp/dep/
 COPY ./pip-freeze.txt ./docker/nginx.site.conf /tmp/
-RUN pip install --no-cache-dir -r /tmp/dep/pip-freeze.txt
+RUN pip install --no-cache-dir -r /tmp/dep/pip-freeze.txt && \
+    pip install -e git+git://github.com/Ilhasoft/rapidpro-apps.git#egg=rapidpro_apps
 
 RUN cp /tmp/nginx.site.conf /etc/nginx/sites-available/$PROJECT.conf \
  && ln -s /etc/nginx/sites-available/$PROJECT.conf /etc/nginx/sites-enabled/$PROJECT.conf

--- a/docker/gunicorn/gunicorn.conf.py
+++ b/docker/gunicorn/gunicorn.conf.py
@@ -1,7 +1,6 @@
 import multiprocessing
 
 workers = multiprocessing.cpu_count() * 2 + 1
-threads = workers
 proc_name = 'rapidpro'
 default_proc_name = proc_name
 accesslog = 'gunicorn.access'

--- a/temba/settings.py.prod
+++ b/temba/settings.py.prod
@@ -187,7 +187,7 @@ ELASTICSEARCH_URL = env("ELASTICSEARCH_URL")
 
 # APPS
 # ------------------------------------------------------------------------------
-INSTALLED_APPS += ("gunicorn", "storages", "elasticapm.contrib.django")
+INSTALLED_APPS += ("gunicorn", "storages", "elasticapm.contrib.django", "weni.channel_stats", "weni.analytics_api",)
 
 # SENTRY
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR depends on https://github.com/Ilhasoft/rapidpro-apps/pull/5

Now rapidpro-apps can be installed as a package, with some changes:

- Instead of "apps.<package_name>", now the available apps are part of "weni" module, like "weni.<app_name>".