### PR TITLE
Update/rapidpro apps

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,8 @@ RUN rm /etc/nginx/sites-enabled/default
 
 COPY ./docker/pip-freeze.txt /tmp/dep/
 COPY ./pip-freeze.txt ./docker/nginx.site.conf /tmp/
-RUN pip install --no-cache-dir -r /tmp/dep/pip-freeze.txt
+RUN pip install --no-cache-dir -r /tmp/dep/pip-freeze.txt && \
+    pip install -e git+git://github.com/Ilhasoft/rapidpro-apps.git#egg=rapidpro_apps
 
 RUN cp /tmp/nginx.site.conf /etc/nginx/sites-available/$PROJECT.conf \
  && ln -s /etc/nginx/sites-available/$PROJECT.conf /etc/nginx/sites-enabled/$PROJECT.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN rm /etc/nginx/sites-enabled/default
 COPY ./docker/pip-freeze.txt /tmp/dep/
 COPY ./pip-freeze.txt ./docker/nginx.site.conf /tmp/
 RUN pip install --no-cache-dir -r /tmp/dep/pip-freeze.txt && \
-    pip install -e git+${RAPIDPRO_APPS_GIT_URL}@${RAPIDPRO_APPS_GIT_BRANCH}#egg=rapidpro_apps
+    pip install -e git+$RAPIDPRO_APPS_GIT_URL@$RAPIDPRO_APPS_GIT_BRANCH#egg=rapidpro_apps
 
 RUN cp /tmp/nginx.site.conf /etc/nginx/sites-available/$PROJECT.conf \
  && ln -s /etc/nginx/sites-available/$PROJECT.conf /etc/nginx/sites-enabled/$PROJECT.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN rm /etc/nginx/sites-enabled/default
 COPY ./docker/pip-freeze.txt /tmp/dep/
 COPY ./pip-freeze.txt ./docker/nginx.site.conf /tmp/
 RUN pip install --no-cache-dir -r /tmp/dep/pip-freeze.txt && \
-    pip install -e git+${RAPIDPRO_APPS_GIT_URL}}@${RAPIDPRO_APPS_GIT_BRANCH}}#egg=rapidpro_apps
+    pip install -e git+${RAPIDPRO_APPS_GIT_URL}@${RAPIDPRO_APPS_GIT_BRANCH}#egg=rapidpro_apps
 
 RUN cp /tmp/nginx.site.conf /etc/nginx/sites-available/$PROJECT.conf \
  && ln -s /etc/nginx/sites-available/$PROJECT.conf /etc/nginx/sites-enabled/$PROJECT.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.6-slim
 ARG COMPRESS_ENABLED
 ARG BRANDING_ENABLED
 
+ARG RAPIDPRO_APPS_GIT_URL
+ARG RAPIDPRO_APPS_GIT_BRANCH
+
 ENV PYTHONUNBUFFERED 1
 ENV DEBIAN_FRONTEND  noninteractive
 
@@ -40,7 +43,7 @@ RUN rm /etc/nginx/sites-enabled/default
 COPY ./docker/pip-freeze.txt /tmp/dep/
 COPY ./pip-freeze.txt ./docker/nginx.site.conf /tmp/
 RUN pip install --no-cache-dir -r /tmp/dep/pip-freeze.txt && \
-    pip install -e git+git://github.com/Ilhasoft/rapidpro-apps.git#egg=rapidpro_apps
+    pip install -e git+${RAPIDPRO_APPS_GIT_URL}}@${RAPIDPRO_APPS_GIT_BRANCH}}#egg=rapidpro_apps
 
 RUN cp /tmp/nginx.site.conf /etc/nginx/sites-available/$PROJECT.conf \
  && ln -s /etc/nginx/sites-available/$PROJECT.conf /etc/nginx/sites-enabled/$PROJECT.conf

--- a/temba/settings.py.prod
+++ b/temba/settings.py.prod
@@ -187,7 +187,7 @@ ELASTICSEARCH_URL = env("ELASTICSEARCH_URL")
 
 # APPS
 # ------------------------------------------------------------------------------
-INSTALLED_APPS += ("gunicorn", "storages", "elasticapm.contrib.django")
+INSTALLED_APPS += ("gunicorn", "storages", "elasticapm.contrib.django", "weni.channel_stats", "weni.analytics_api",)
 
 # SENTRY
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR depends on Ilhasoft/rapidpro-apps#5

Now rapidpro-apps can be installed as a package, with some changes:

Instead of "apps.<package_name>", now the available apps are part of "weni" module, like "weni.<app_name>".