### PR TITLE
Adds support to customize OpenID Connect scopes

### DIFF
--- a/temba/settings.py.prod
+++ b/temba/settings.py.prod
@@ -308,6 +308,7 @@ OIDC_OP_TOKEN_ENDPOINT = env("OIDC_OP_TOKEN_ENDPOINT")
 OIDC_OP_USER_ENDPOINT = env("OIDC_OP_USER_ENDPOINT")
 OIDC_OP_JWKS_ENDPOINT = env("OIDC_OP_JWKS_ENDPOINT")
 OIDC_RP_SIGN_ALGO = env("OIDC_RP_SIGN_ALGO", default="RS256")
+OIDC_RP_SCOPES = env("OIDC_RP_SCOPES", default= "openid email")
 
 # Tells Django to authenticate via OIDC
 AUTHENTICATION_BACKENDS += ("weni.auth.backends.WeniOIDCAuthenticationBackend",)


### PR DESCRIPTION
Adds OIDC_RP_SCOPES setting at temba/settings.py.prod.

This setting allows to set which connect scopes our application should request to OP. In our case, we need to request offline_access to obtain a refresh token and avoid random disconnects when using rapidpro within Weni's Connect.