### PR TITLE
Feat: exclude HTTP headers

### DIFF
--- a/temba/settings.py.prod
+++ b/temba/settings.py.prod
@@ -379,3 +379,6 @@ CSP_CONNECT_SRC = env.tuple("CSP_CONNECT_SRC", default=CSP_DEFAULT_SRC)
 
 # Removes 'check-channels' task from Beat Schedule (sent_messages query)
 CELERYBEAT_SCHEDULE.pop('check-channels')
+
+# Exclude list of header that should not appear in webhook and channel logs
+EXCLUDED_HTTP_HEADERS = env.list("EXCLUDED_HTTP_HEADERS", default=[])\


### PR DESCRIPTION
Checks if HTTP headers contains one of the excluded words defined in settings as env vars such as:
- Authorization
- X-Api-Key
- Api-Key
- Token