### PR TITLE
use original name on uploaded file

### DIFF
--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -723,7 +723,7 @@ class FlowCRUDL(SmartCRUDL):
 
         def save_media_upload(self, file):
             flow = self.get_object()
-            name_uuid = str(uuid4())
+            uuid = str(uuid4())
             extension = file.name.split(".")[-1]
 
             # browsers might send m4a files but correct MIME type is audio/mp4
@@ -731,7 +731,7 @@ class FlowCRUDL(SmartCRUDL):
                 file.content_type = "audio/mp4"
 
             url = public_file_storage.save(
-                "attachments/%d/%d/steps/%s.%s" % (flow.org.pk, flow.id, name_uuid, extension), file
+                "attachments/%d/%d/steps/%s/%s" % (flow.org.pk, flow.id, uuid, file.name), file
             )
             return {"type": file.content_type, "url": f"{settings.STORAGE_URL}/{url}"}
 


### PR DESCRIPTION
use the original filename instead of a uuid when uploading the file.