### PR TITLE
Downgrade elasticsearch version to 7.13.4

### DIFF
--- a/docker/pip-requires.txt
+++ b/docker/pip-requires.txt
@@ -4,3 +4,4 @@ flower@^0.9
 django-templates-macros@^0.2
 django-csp@^3.7
 weni-rp-apps@==1.0.12
+elasticsearch==7.13.4


### PR DESCRIPTION
This PR aims to solve the: `elasticsearch.exceptions.UnsupportedProductError: The client noticed that the server is not a supported distribution of Elasticsearch`

The problem is explained in the following issue: https://github.com/rapidpro/rapidpro/issues/1613