### PR TITLE
Redirect advice

### DIFF
--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -241,6 +241,6 @@ class RedirectMiddleware:
         if hasattr(settings, 'WENI_DOMAINS'):
             if use_weni_layout(request)['use_weni_layout']:
                 return self.get_response(request)
-        if not request.path.startswith("/redirect"):
+        if not request.path.startswith("/redirect") and not request.path.startswith("/api"):
             return HttpResponseRedirect(reverse("weni.redirect"))
         return self.get_response(request)

--- a/temba/settings.py.prod
+++ b/temba/settings.py.prod
@@ -440,3 +440,10 @@ if DISABLE_OIDC:
     AUTHENTICATION_BACKENDS = tuple(authentication_backend_list)
 
     OIDC_DRF_AUTH_BACKEND = None
+
+# ----------------------------------------------------------------------------------------
+# Option to enable redirect all routes (except api), to redirect view 
+# ----------------------------------------------------------------------------------------
+WENI_REDIRECT_DEPRECATED_DOMAIN = env.bool("WENI_REDIRECT_DEPRECATED_DOMAIN", default=False)
+if WENI_REDIRECT_DEPRECATED_DOMAIN:
+    MIDDLEWARE = ("temba.middleware.RedirectMiddleware",) + MIDDLEWARE

--- a/temba/urls.py
+++ b/temba/urls.py
@@ -10,6 +10,8 @@ from celery.signals import worker_process_init
 from temba.channels.views import register, sync
 from temba.utils.analytics import init_analytics
 
+from .views import WeniRedirect
+
 # javascript translation packages
 js_info_dict = {"packages": ()}  # this is empty due to the fact that all translation are in one folder
 
@@ -43,6 +45,7 @@ urlpatterns = [
     url(r"^imports/", include("smartmin.csv_imports.urls")),
     url(r"^assets/", include("temba.assets.urls")),
     url(r"^jsi18n/$", JavaScriptCatalog.as_view(), js_info_dict, name="django.views.i18n.javascript_catalog"),
+    url(r"^redirect/", WeniRedirect.as_view(), {}, "weni.redirect")
 ]
 
 if settings.DEBUG:

--- a/temba/views.py
+++ b/temba/views.py
@@ -1,0 +1,4 @@
+from smartmin.views import SmartTemplateView
+
+class WeniRedirect(SmartTemplateView):
+    template_name = "weni/redirect.haml"

--- a/templates/weni/redirect.haml
+++ b/templates/weni/redirect.haml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+-load compress i18n
+%html
+  %head
+    %meta{name:"viewport",content:"width=device-width, initial-scale=1.0"}
+    %title
+      {{ brand.name }} Redirect
+    :css
+      body { 
+        margin: 0 
+      }
+    -compress css
+      {% lessblock %}
+        :plain
+          @import (optional) "../brands/{{brand.slug}}/less/style.less";
+      {% endlessblock %}
+
+      // any additional brand styling such as fonts, etc
+      -for style in brand.styles
+        -if 'less' in style
+          %link{type:'text/less', rel:'stylesheet', href:'/sitestatic/{{style}}', media:'all'}
+        -else
+          %link{type:'text/css', rel:'stylesheet', href:"/sitestatic/{{style}}", media:'all'}
+
+  %body
+    #redirect-splash
+      %div.rbackground
+      %div.rinfo
+        %div.rtitle
+          Este link não está mais disponível
+        %div.rdesc
+          Agora você acessa seus projetos em
+          %a{href:"https://dash.weni.ai"}
+            https://dash.weni.ai
+  

--- a/templates/weni/redirect.haml
+++ b/templates/weni/redirect.haml
@@ -40,6 +40,6 @@
         %div.rdesc
           Em caso de dúvidas, entre em contato conosco através do e-mail
           %br
-          %a{href:"suporte@weni.ai"}
+          %a{href:"mailto:suporte@weni.ai"}
             suporte@weni.ai
   

--- a/templates/weni/redirect.haml
+++ b/templates/weni/redirect.haml
@@ -25,11 +25,21 @@
   %body
     #redirect-splash
       %div.rbackground
+      %div.rlogo
+        %a{href:"https://dash.weni.ai"}
+          %img{src:"/sitestatic/brands/push/logo-weni.png",width:84, height:24}
+
       %div.rinfo
         %div.rtitle
-          Este link não está mais disponível
+          Este página não está mais disponível
         %div.rdesc
-          Agora você acessa seus projetos em
+          Agora você acessa seus projetos através da plataforma
           %a{href:"https://dash.weni.ai"}
             https://dash.weni.ai
+        %br
+        %div.rdesc
+          Em caso de dúvidas, entre em contato conosco através do e-mail
+          %br
+          %a{href:"suporte@weni.ai"}
+            suporte@weni.ai
   


### PR DESCRIPTION
feature to redirect users to a redirect view when access any route except `/api`. 

to achieve this, set `WENI_REDIRECT_DEPRECATED_DOMAIN` env var to `true` and this works for any domain where application is accessed is not one in `WENI_DOMAINS`.