### PR TITLE
Downgrade Sentry version from 1.9.9 to 1.9.8

### DIFF
--- a/docker/pip-requires.txt
+++ b/docker/pip-requires.txt
@@ -7,3 +7,4 @@ weni-rp-apps@==1.0.26
 elasticsearch==7.13.4
 slack_sdk==3.17.0
 dulwich==0.20.45
+sentry-sdk==1.9.8


### PR DESCRIPTION
The 1.9.9 version of sentry-sdk is raising an AttributeError:
```
AttributeError: 'functools.partial' object has no attribute '__module__'
```
This version was updated 3 days ago
![image](https://user-images.githubusercontent.com/49874732/193076586-2b4b15ce-c93c-4d38-bcbf-3cc67ffb8c2f.png)

 to solve this problem this PR lowers the version from 1.9.9 to 1.9.8