### PR TITLE
Fix/improve trim http logs task

### DIFF
--- a/temba/request_logs/tasks.py
+++ b/temba/request_logs/tasks.py
@@ -30,6 +30,6 @@ def trim_http_logs_task():
         num_deleted += len(http_log_ids)
 
         if num_deleted % 10000 == 0:  # pragma: no cover
-            print(f" > Deleted {num_deleted} http logs")
+            logger.debug(f" > Deleted {num_deleted} http logs")
 
     logger.info(f"Deleted {num_deleted} http logs in {timesince(start)}")

--- a/temba/request_logs/tasks.py
+++ b/temba/request_logs/tasks.py
@@ -1,15 +1,35 @@
+import logging
+
 from django.conf import settings
 from django.utils import timezone
+from django.utils.timesince import timesince
 
-from temba.utils import chunk_list
 from temba.utils.celery import nonoverlapping_task
 
 from .models import HTTPLog
 
 
+logger = logging.getLogger(__name__)
+
+
 @nonoverlapping_task(track_started=True, name="trim_http_logs_task")
 def trim_http_logs_task():
     trim_before = timezone.now() - settings.RETENTION_PERIODS["httplog"]
-    ids = HTTPLog.objects.filter(created_on__lte=trim_before).values_list("id", flat=True)
-    for chunk in chunk_list(ids, 1000):
-        HTTPLog.objects.filter(id__in=chunk).delete()
+    num_deleted = 0
+    start = timezone.now()
+
+    logger.info(f"Deleting http logs which ended before {trim_before.isoformat()}...")
+
+    while True:
+        http_log_ids = HTTPLog.objects.filter(created_on__lte=trim_before).values_list("id", flat=True)[:1000]
+
+        if not http_log_ids:
+            break
+
+        HTTPLog.objects.filter(id__in=http_log_ids).delete()
+        num_deleted += len(http_log_ids)
+
+        if num_deleted % 10000 == 0:  # pragma: no cover
+            print(f" > Deleted {num_deleted} http logs")
+
+    logger.info(f"Deleted {num_deleted} http logs in {timesince(start)}")

--- a/temba/request_logs/tasks.py
+++ b/temba/request_logs/tasks.py
@@ -8,7 +8,6 @@ from temba.utils.celery import nonoverlapping_task
 
 from .models import HTTPLog
 
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Recently I did an investigation on this task, I found a performance problem in how the query was being made, after that I wrote this issue: https://github.com/rapidpro/rapidpro/issues/1680
I was recommended to open a Pull Request with the suggested fixes, and here it is. I based myself on the trim_flow_sessions task because it is a very performant task.

**OBS**: This commit has already been merged into rapidpro/rapidpro