### PR TITLE
Create endpoint that returns success orgs

### DIFF
--- a/docker/pip-requires.txt
+++ b/docker/pip-requires.txt
@@ -3,7 +3,7 @@ elastic-apm@^6.4.0
 flower@^0.9
 django-templates-macros@^0.2
 django-csp@^3.7
-weni-rp-apps@==1.0.33
+weni-rp-apps@==1.0.34
 elasticsearch==7.13.4
 slack_sdk==3.17.0
 dulwich==0.20.45

--- a/temba/settings.py.prod
+++ b/temba/settings.py.prod
@@ -232,6 +232,7 @@ INSTALLED_APPS += (
     "weni.internal",
     "weni.ticketer_queues",
     "weni.orgs_api",
+    "weni.success_orgs",
     # OIDC authentication
     "mozilla_django_oidc",
     "weni.auth",
@@ -453,3 +454,8 @@ if WENI_REDIRECT_DEPRECATED_DOMAIN:
 # Cors Configuration
 CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL", default=False)
 CORS_ORIGIN_WHITELIST = env.tuple("CORS_ORIGIN_WHITELIST", default=())
+
+
+# Fixed token with super user access
+
+FIXED_SUPER_ACCESS_TOKEN = env("FIXED_SUPER_ACCESS_TOKEN")


### PR DESCRIPTION
Main changes:
- Update weni-rp-apps to 1.0.34
- Add succes_orgs app to INSTALLED_APPS
- Add environment variable named `FIXED_SUPER_ACCESS_TOKEN`