### PR TITLE
Revert "fix: add weni.s3 to installed_apps"

### DIFF
--- a/temba/settings.py.prod
+++ b/temba/settings.py.prod
@@ -234,7 +234,6 @@ INSTALLED_APPS += (
     "weni.internal",
     "weni.ticketer_queues",
     "weni.orgs_api",
-    "weni.s3",
     "weni.success_orgs",
     "weni.activities",
     # OIDC authentication


### PR DESCRIPTION
Reverts Ilhasoft/rapidpro#405

This PR will be reverted because it generated the following error:
```py
...
    from .views import WeniFileCallbackView
  File "/usr/local/lib/python3.9/site-packages/weni/s3/views.py", line 3, in <module>
    import magic
  File "/usr/local/lib/python3.9/site-packages/magic/__init__.py", line 209, in <module>
    libmagic = loader.load_lib()
  File "/usr/local/lib/python3.9/site-packages/magic/loader.py", line 49, in load_lib
    raise ImportError('failed to find libmagic.  Check your installation')
ImportError: failed to find libmagic.  Check your installation
```