### PR TITLE
Set import_contacts_task queue

### DIFF
--- a/temba/temba_celery.py
+++ b/temba/temba_celery.py
@@ -23,5 +23,5 @@ app.autodiscover_tasks(
 # TODO: Move logic to settings.py.prod or rapidpro-apps
 app.conf.task_routes = {
     'create_recent_activity': {'queue': 'async'},
-    'import_contacts_task': {'queue': 'import'},
+    'temba.contacts.tasks.import_contacts_task': {'queue': 'import'},
 }

--- a/temba/temba_celery.py
+++ b/temba/temba_celery.py
@@ -23,4 +23,5 @@ app.autodiscover_tasks(
 # TODO: Move logic to settings.py.prod or rapidpro-apps
 app.conf.task_routes = {
     'create_recent_activity': {'queue': 'async'},
+    'import_contacts_task': {'queue': 'import'},
 }


### PR DESCRIPTION
The task will always be sent to the `import` queue in order to reduce concurrency between tasks and improve independent scalability.