### PR TITLE
Fix: Rollback weni-rp-apps to 1.0.33a0 due to Django 4 compatibility issues

### DIFF
--- a/docker/pip-requires.txt
+++ b/docker/pip-requires.txt
@@ -3,7 +3,7 @@ elastic-apm@^6.4.0
 flower@^0.9
 django-templates-macros@^0.2
 django-csp@^3.7
-weni-rp-apps@==2.1.3
+weni-rp-apps@==1.0.33a0
 elasticsearch==7.13.4
 slack_sdk==3.17.0
 dulwich==0.20.45

--- a/temba/settings.py.prod
+++ b/temba/settings.py.prod
@@ -235,9 +235,6 @@ INSTALLED_APPS += (
     "weni.grpc.billing",
     "weni.grpc.statistic",
     "weni.orgs_api",
-    "weni.s3",
-    "weni.success_orgs",
-    "weni.activities",
     # OIDC authentication
     "mozilla_django_oidc",
     "weni.auth",


### PR DESCRIPTION
- The weni-rp-apps package is not yet compatible with Django 4. For that, we use an earlier alpha version created to mitigate that.
- Removed apps that do not yet exists in this earlier version